### PR TITLE
waiting for table to be ready

### DIFF
--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/DynamoDBBuilders.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/DynamoDBBuilders.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Alessandro Moscatelli
  */
 
 package org.eclipse.jnosql.communication.dynamodb;

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/DynamoDBUtils.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/DynamoDBUtils.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Alessandro Moscatelli
  */
 package org.eclipse.jnosql.communication.dynamodb;
 

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/DynamoTableUtils.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/DynamoTableUtils.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Alessandro Moscatelli
  */
 package org.eclipse.jnosql.communication.dynamodb;
 
@@ -134,12 +135,15 @@ public final class DynamoTableUtils {
 
         Map<String, KeyType> keyDefinition = createKeyDefinition();
         Map<String, ScalarAttributeType> attributeDefinition = createAttributesType();
-
+        
         client.createTable(CreateTableRequest.builder()
                 .tableName(tableName)
                 .provisionedThroughput(createProvisionedThroughput(readCapacityUnits, writeCapacityUnit))
                 .keySchema(createKeyElementSchema(keyDefinition))
                 .attributeDefinitions(createAttributeDefinition(attributeDefinition))
                 .build());
+        
+        client.waiter().waitUntilTableExists(t -> t.tableName(tableName));
+        
     }
 }

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/keyvalue/DynamoDBBucketManager.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/keyvalue/DynamoDBBucketManager.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Alessandro Moscatelli
  */
 package org.eclipse.jnosql.communication.dynamodb.keyvalue;
 


### PR DESCRIPTION
We were creating the table without waiting for it to be ready.
This caused the table not to be ready and a Resource not found Exception was thrown from aws.
This happens only when using in cloud dynamodb table, I could not reproduce the issue when using the local dynamodb docker instance.


Also adding myself as contributor where I previously contributed.
