### PR TITLE
DynamoDB Document Driver

### DIFF
--- a/dynamodb-driver/pom.xml
+++ b/dynamodb-driver/pom.xml
@@ -1,47 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright (c) 2017 Otávio Santana and others ~ All rights reserved. 
-	This program and the accompanying materials ~ are made available under the 
-	terms of the Eclipse Public License v1.0 ~ and Apache License v2.0 which 
-	accompanies this distribution. ~ The Eclipse Public License is available 
-	at http://www.eclipse.org/legal/epl-v10.html ~ and the Apache License v2.0 
-	is available at http://www.opensource.org/licenses/apache2.0.php. ~ ~ You 
-	may elect to redistribute this code under either of these licenses. ~ ~ Contributors: 
-	~ ~ Otavio Santana -->
+<!-- ~ Copyright (c) 2022 Otávio Santana and others ~ All rights reserved. 
+This program and the accompanying materials ~ are made available under the 
+terms of the Eclipse Public License v1.0 ~ and Apache License v2.0 which 
+accompanies this distribution. ~ The Eclipse Public License is available 
+at http://www.eclipse.org/legal/epl-v10.html ~ and the Apache License v2.0 
+is available at http://www.opensource.org/licenses/apache2.0.php. ~ ~ You 
+may elect to redistribute this code under either of these licenses. ~ ~ Contributors: 
+~ ~ Otavio Santana 
+~ ~ Alessandro Moscatelli -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.eclipse.jnosql.communication</groupId>
-		<artifactId>communication-driver</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-	</parent>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.jnosql.communication</groupId>
+        <artifactId>communication-driver</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
 
 
-	<artifactId>dynamodb-driver</artifactId>
+    <artifactId>dynamodb-driver</artifactId>
 
-	<dependencies>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>communication-key-value</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>communication-driver-commons</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-    		<artifactId>dynamodb</artifactId>
-    		<version>2.15.40</version>
-		</dependency>
-		<dependency>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>communication-key-value</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>communication-document</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>communication-driver-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <version>2.17.99</version>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-	</dependencies>
+    </dependencies>
 </project>

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentCollectionManager.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentCollectionManager.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2022 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Alessandro Moscatelli
+ */
+package org.eclipse.jnosql.communication.dynamodb.document;
+
+import jakarta.nosql.document.DocumentCollectionManager;
+import jakarta.nosql.document.DocumentDeleteQuery;
+import jakarta.nosql.document.DocumentEntity;
+import jakarta.nosql.document.DocumentQuery;
+import java.time.Duration;
+import java.util.stream.Stream;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class DynamoDBDocumentCollectionManager implements DocumentCollectionManager {
+
+    private final DynamoDbClient client;
+    private final String tableName;
+    private Boolean initializeTable;
+
+    public DynamoDBDocumentCollectionManager(
+            DynamoDbClient client,
+            String tableName,
+            Boolean initializeTable
+    ) {
+        this.client = client;
+        this.tableName = tableName;
+        this.initializeTable = initializeTable;
+    }
+    
+    private void checkTable(DocumentEntity de) {
+        if (initializeTable) {
+            DynamoDocumentTableUtils.createTable(tableName, client, de, null, null);
+            initializeTable = Boolean.FALSE;
+        }
+    }
+
+    @Override
+    public DocumentEntity insert(DocumentEntity de) {
+        checkTable(de);
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DocumentEntity insert(DocumentEntity de, Duration drtn) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<DocumentEntity> insert(Iterable<DocumentEntity> itrbl) {
+        checkTable(itrbl.iterator().next());
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Iterable<DocumentEntity> insert(Iterable<DocumentEntity> itrbl, Duration drtn) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DocumentEntity update(DocumentEntity de) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Iterable<DocumentEntity> update(Iterable<DocumentEntity> itrbl) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void delete(DocumentDeleteQuery ddq) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Stream<DocumentEntity> select(DocumentQuery dq) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public long count(String string) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void close() {
+        this.client.close();
+    }
+
+}

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentCollectionManager.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentCollectionManager.java
@@ -21,6 +21,7 @@ import jakarta.nosql.document.DocumentQuery;
 import java.time.Duration;
 import java.util.stream.Stream;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 
 public class DynamoDBDocumentCollectionManager implements DocumentCollectionManager {
 
@@ -48,7 +49,8 @@ public class DynamoDBDocumentCollectionManager implements DocumentCollectionMana
     @Override
     public DocumentEntity insert(DocumentEntity de) {
         checkTable(de);
-        throw new UnsupportedOperationException();
+        client.putItem(PutItemRequest.builder().tableName(tableName).item(DynamoDocumentTableUtils.createAttributesMap(de)).build());
+        return de;
     }
 
     @Override

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentCollectionManagerFactory.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentCollectionManagerFactory.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2022 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Alessandro Moscatelli
+ */
+
+package org.eclipse.jnosql.communication.dynamodb.document;
+
+import jakarta.nosql.document.DocumentCollectionManagerFactory;
+import org.eclipse.jnosql.communication.dynamodb.DynamoTableUtils;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class DynamoDBDocumentCollectionManagerFactory implements DocumentCollectionManagerFactory {
+
+    private final DynamoDbClient client;
+    
+    DynamoDBDocumentCollectionManagerFactory(DynamoDbClient client) {
+        this.client = client;
+    }
+    
+    @Override
+    public DynamoDBDocumentCollectionManager get(String tableName) {
+        return new DynamoDBDocumentCollectionManager(client, tableName, !DynamoTableUtils.existTable(tableName, client));
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+    
+}

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentConfiguration.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDBDocumentConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2022 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Alessandro Moscatelli
+ */
+
+package org.eclipse.jnosql.communication.dynamodb.document;
+
+import jakarta.nosql.Settings;
+import jakarta.nosql.document.DocumentConfiguration;
+import org.eclipse.jnosql.communication.dynamodb.DynamoDBConfiguration;
+
+public class DynamoDBDocumentConfiguration extends DynamoDBConfiguration implements DocumentConfiguration {
+    
+    @Override
+    public DynamoDBDocumentCollectionManagerFactory get() {
+        return new DynamoDBDocumentCollectionManagerFactory(
+                builder.build()
+        );
+    }
+
+    @Override
+    public DynamoDBDocumentCollectionManagerFactory get(Settings stngs) {
+        return new DynamoDBDocumentCollectionManagerFactory(
+                getDynamoDB(stngs)
+        );
+    }
+    
+}

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDocumentTableUtils.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/DynamoDocumentTableUtils.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2022 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Alessandro Moscatelli
+ */
+package org.eclipse.jnosql.communication.dynamodb.document;
+
+import jakarta.nosql.document.DocumentEntity;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import static org.eclipse.jnosql.communication.dynamodb.DynamoTableUtils.createAttributeDefinition;
+import static org.eclipse.jnosql.communication.dynamodb.DynamoTableUtils.createKeyElementSchema;
+import static org.eclipse.jnosql.communication.dynamodb.DynamoTableUtils.createProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+public final class DynamoDocumentTableUtils {
+
+    static final Collection<Class> nTypes = Arrays.asList(Number.class, Boolean.class);
+    static final Collection<Class> sTypes = Arrays.asList(Date.class, String.class);
+    static final String ID_FIELD = "_id";
+
+    private DynamoDocumentTableUtils() {
+    }
+
+    public static <T> ScalarAttributeType getScalarAttributeType(T value) {
+        if (nTypes.stream().anyMatch(type -> type.isInstance(value))) {
+            return ScalarAttributeType.N;
+        } else if (sTypes.stream().anyMatch(type -> type.isInstance(value))) {
+            return ScalarAttributeType.S;
+        }
+        return ScalarAttributeType.UNKNOWN_TO_SDK_VERSION;
+    }
+
+    public static Map<String, KeyType> createKeyDefinition(DocumentEntity documentEntity) {
+        return Collections.singletonMap(ID_FIELD, KeyType.HASH);
+    }
+
+    public static Map<String, ScalarAttributeType> createAttributesType(DocumentEntity documentEntity) {
+        return Map.ofEntries(
+                documentEntity.getDocuments().stream().map(
+                        document -> new AbstractMap.SimpleEntry<>(
+                                document.getName(),
+                                getScalarAttributeType(document.getValue().get())
+                        )
+                ).toArray(
+                        AbstractMap.SimpleEntry[]::new
+                )
+        );
+    }
+
+    public static void createTable(String tableName, DynamoDbClient client, DocumentEntity documentEntity, Long readCapacityUnits, Long writeCapacityUnit) {
+
+        client.createTable(
+                CreateTableRequest.builder()
+                        .tableName(tableName)
+                        .provisionedThroughput(
+                                createProvisionedThroughput(readCapacityUnits, writeCapacityUnit)
+                        )
+                        .keySchema(
+                                createKeyElementSchema(
+                                        Collections.singletonMap(
+                                                ID_FIELD,
+                                                KeyType.HASH
+                                        )
+                                )
+                        )
+                        .attributeDefinitions(
+                                createAttributeDefinition(
+                                        Collections.singletonMap(
+                                                ID_FIELD,
+                                                getScalarAttributeType(
+                                                        documentEntity.find(ID_FIELD).get().getValue().get()
+                                                )
+                                        )
+                                )
+                        )
+                        .build()
+        );
+
+        client.waiter().waitUntilTableExists(t -> t.tableName(tableName));
+
+    }
+
+}

--- a/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/package-info.java
+++ b/dynamodb-driver/src/main/java/org/eclipse/jnosql/communication/dynamodb/document/package-info.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2022 Otávio Santana and others
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Alessandro Moscatelli
+ */
+
+/**
+ * The mongodb document implementation
+ */
+package org.eclipse.jnosql.communication.dynamodb.document;


### PR DESCRIPTION
Hi everybody !
I started working on DynamoDB Document Driver.
I am anticipating the pull request because I have some difficulties/perplexities :

- How can retrieve the ID Column actual name inside the DocumentCollectionManager ?
I expected to be able to access the base java type I have to convert the data from/to to inspect annotations.

I looked at the MongoDB Document Driver and there you always use "_id" constant as id column name.
Isn't this againt the specification ?
In the Document example I see you are supposed to change that.

- Also, won't not being able to access the source java type cause issues in future to properly manage Polymorphism ?
I would expect DocumentConfiguration, DocumentCollectionManagerFactory, DocumentCollectionManager, DocumentEntity to be generic types/interfaces, examples : DocumentConfiguration< Product >, DocumentCollectionManagerFactory< Product >, DocumentCollectionManager< Product >, DocumentEntity< Product > and pass the base type in their methods as a parameter.

- Last but not least, in DocumentCollectionManagerFactory could be usefull to access the base java type also to initialize connection with the nosql database (for example at the moment I am forced to initialize the DynamoDB table inside the DocumentCollectionManager to look for DocumentEntity attributes (aka Documents if I understood correctly). DynamoDB is schema less regarding attributes, but you have to initialize KeySchema regarding the primary key/keys and that can't be changed later.

Thank you id advance.

@otaviojava 
 