### PR TITLE
Mark EntityAttachment implementations as public

### DIFF
--- a/communication-driver-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/ByteArrayEntityAttachment.java
+++ b/communication-driver-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/ByteArrayEntityAttachment.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
  * 
  * @since 0.0.9
  */
-class ByteArrayEntityAttachment implements EntityAttachment {
+public class ByteArrayEntityAttachment implements EntityAttachment {
     private final String name;
     private final String contentType;
     private final long lastModified;

--- a/communication-driver-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/PathEntityAttachment.java
+++ b/communication-driver-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/PathEntityAttachment.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * 
  * @since 0.0.9
  */
-class PathEntityAttachment implements EntityAttachment {
+public class PathEntityAttachment implements EntityAttachment {
     private final Path path;
     
     public PathEntityAttachment(Path path) {


### PR DESCRIPTION
Currently, the two classes used by the `EntityAttachment.of` methods are package-private. This causes trouble when passed to Yasson for JSON-B conversion. Specifically:

```
java.lang.IllegalAccessException: Class 'org.eclipse.yasson.internal.model.ModulesUtil' no access to: class 'org.eclipse.jnosql.communication.driver.attachment.ByteArrayEntityAttachment'
	at java.lang.invoke.MethodHandles$Lookup.checkClassAccess(MethodHandles.java:475)
	at java.lang.invoke.MethodHandles$Lookup.checkAccess(MethodHandles.java:371)
	at java.lang.invoke.MethodHandles$Lookup.checkAccess(MethodHandles.java:346)
	at java.lang.invoke.MethodHandles$Lookup.unreflect(MethodHandles.java:1034)
	at org.eclipse.yasson.internal.model.PropertyModel.createReadHandle(PropertyModel.java:541)
	... 77 more
```